### PR TITLE
File xfer gradle fixes and fix for subdir 

### DIFF
--- a/src/main/java/com/circron/filexfer/Utils.java
+++ b/src/main/java/com/circron/filexfer/Utils.java
@@ -102,7 +102,7 @@ public class Utils {
             }
             try {
                 Path basePath = Paths.get(".");
-                if (Files.isDirectory(Paths.get(fileTransferFile.getPath()))) basePath = Paths.get(fileTransferFile.getPath()).getParent();
+                if (Files.isDirectory(Paths.get(fileTransferFile.getPath()))) basePath = Paths.get(fileTransferFile.getPath());
                 Path finalBasepath = basePath;
                 Files.walk(Paths.get(fileTransferFile.getPath())).forEach(f -> {
                     FileTransferFile tempFileTransferFile = new FileTransferFile(f.toFile());


### PR DESCRIPTION
@cngann, I made a fix for the subdir issue in the Utils class. I tested the fix and it works fine in my case where contents of /opt/d4voip/upgrade/update1 excluding subdir update1 get copied to workdir/ correctly. Not sure if the fix affects other logics in your original design though.